### PR TITLE
feat: add support for passing channel params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3-nullsafety
+
+- Allow to pass additional channel params on connection. Introduced `getChannelParamsFunc`.
+
 ## 0.0.2-nullsafety
 
 - Add support for Dart SDK < 4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: graphql_action_cable_link
 description: A Link for GraphQL Subscription backed by Rails ActionCable WebSocket server (graphql-ruby.org)
-version: 0.0.2-nullsafety
+version: 0.0.3-nullsafety
 homepage: https://github.com/khaiql/graphql_action_cable_link
 
 environment:


### PR DESCRIPTION
This change utilizes the channel params option of the action cable. Allows additional parameters to be sent through the initial channel subscription.